### PR TITLE
Removing jQuery as dependency

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -2,8 +2,7 @@
 
 var url = require('url'),
     queryString = require('querystring'),
-    _ = require('underscore'),
-    $ = require('jquery');
+    _ = require('underscore');
 
 /**
  * Constructor to the Response object
@@ -51,10 +50,6 @@ Response.prototype.getBody = function() {
 
     if (responseType.indexOf('application/x-www-form-urlencoded') !== -1) {
         return queryString.parse(this.body);
-    }
-
-    if (responseType.indexOf('xml') !== -1) {
-        return $(this.body);
     }
 
     return this.body;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestify",
   "description": "Simplifies node HTTP request making (HTTP client) with caching support.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "test": "mocha -R spec test/**/*.js test/*.js"
   },
@@ -23,8 +23,7 @@
   "author": "Ran Mizrahi <ranm@codeoasis.com>",
   "dependencies": {
     "q": "~1.2.0",
-    "underscore": "~1.8.3",
-    "jquery": "~2.1.3"
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "mocha": "~1.9.0",


### PR DESCRIPTION
We don’t use the `getBody` method and don’t use the xml parsing